### PR TITLE
fix: check if mActivity is null

### DIFF
--- a/android/src/main/java/com/rhaker/reactnativeselectcontacts/SelectContactsManager.java
+++ b/android/src/main/java/com/rhaker/reactnativeselectcontacts/SelectContactsManager.java
@@ -48,7 +48,10 @@ public class SelectContactsManager extends ReactContextBaseJavaModule implements
 
   // handle the user selection of a certain contact
   public boolean handleActivityResult(final int requestCode, final int resultCode, final Intent data) {
-
+      // check if pickContact was invoked else opt out of activity
+      if(mActivity == null){
+          return false;
+      }
       switch (requestCode) {
 
           case (PICK_CONTACT) :

--- a/android/src/main/java/com/rhaker/reactnativeselectcontacts/SelectContactsManager.java
+++ b/android/src/main/java/com/rhaker/reactnativeselectcontacts/SelectContactsManager.java
@@ -50,6 +50,7 @@ public class SelectContactsManager extends ReactContextBaseJavaModule implements
   public boolean handleActivityResult(final int requestCode, final int resultCode, final Intent data) {
       // check if pickContact was invoked else opt out of activity
       if(mActivity == null){
+          Log.i("RNSelectContacts", "mActivity is null, may not be the current intent or there is a problem");
           return false;
       }
       switch (requestCode) {


### PR DESCRIPTION
If pickContact is not invoked then mActivity will be null

This PR adds a check for this case so when android cycles through the activity results, it will pass over without throwing an error.

eg of error I was getting even when not using the module

``` java
AndroidRuntime: Caused by: java.lang.NullPointerException: Attempt to invoke virtual method 'android.database.Cursor android.app.Activity.managedQuery(android.net.Uri, java.lang.String[], java.lang.String, java.lang.String[], java.lang.String)' on a null object reference
09-28 18:55:52.487  8111  8111 E AndroidRuntime:    at com.rhaker.reactnativeselectcontacts.SelectContactsManager.handleActivityResult(SelectContactsManager.java:60)
09-28 18:55:52.487  8111  8111 E AndroidRuntime:    at com.rhaker.reactnativeselectcontacts.SelectContactsManager.onActivityResult(SelectContactsManager.java:47)
09-28 18:55:52.487  8111  8111 E AndroidRuntime:    at com.facebook.react.bridge.ReactContext.onActivityResult(ReactContext.java:210)
09-28 18:55:52.487  8111  8111 E AndroidRuntime:    at com.facebook.react.XReactInstanceManagerImpl.onActivityResult(XReactInstanceManagerImpl.java:612)
09-28 18:55:52.487  8111  8111 E AndroidRuntime:    at com.facebook.react.ReactActivityDelegate.onActivityResult(ReactActivityDelegate.java:134)
09-28 18:55:52.487  8111  8111 E AndroidRuntime:    at com.facebook.react.ReactActivity.onActivityResult(ReactActivity.java:77)
09-28 18:55:52.487  8111  8111 E AndroidRuntime:    at android.app.Activity.dispatchActivityResult(Activity.java:6428)
09-28 18:55:52.487  8111  8111 E AndroidRuntime:    at android.app.ActivityThread.deliverResults(ActivityThread.java:3695)
```
