### PR TITLE
RN 0.47 compatibility

### DIFF
--- a/android/src/main/java/com/rhaker/reactnativeselectcontacts/ReactNativeSelectContacts.java
+++ b/android/src/main/java/com/rhaker/reactnativeselectcontacts/ReactNativeSelectContacts.java
@@ -24,7 +24,6 @@ public class ReactNativeSelectContacts implements ReactPackage {
     return Arrays.<NativeModule>asList(mModuleInstance);
   }
 
-  @Override
   public List<Class<? extends JavaScriptModule>> createJSModules() {
     return Collections.emptyList();
   }


### PR DESCRIPTION
`createJSModules` is removed in RN 47, so if we remove the `@Override` this allows 0.47 to compile and is backwards compatible